### PR TITLE
AND ( (CONDITION A AND CONDITION B) OR CONDITION C)

### DIFF
--- a/src/Db/MySQL/Query/Utilities/Condition.php
+++ b/src/Db/MySQL/Query/Utilities/Condition.php
@@ -86,7 +86,9 @@ final class Condition
                     $ret[] = \sprintf('(%s)', $this->parse($val, ' OR '));
                 } elseif(\preg_match('/^\$and[0-9]*$/', $key)) {
                     $ret[] = \sprintf('(%s)', $this->parse($val, ' AND '));
-                } else $ret[] = $this->parseExpression($key, $val, $logicalOperator);
+                } else {
+                    $ret[] = $this->parseExpression($key, $val, $logicalOperator);
+                }
             } elseif (\is_string($key) && \in_array(gettype($val), ['integer', 'double', 'string'])) {
                 $ret[] = \sprintf('%s=%s', $key, $this->escapeClass->escape($val));
             }

--- a/src/Db/MySQL/Query/Utilities/Condition.php
+++ b/src/Db/MySQL/Query/Utilities/Condition.php
@@ -84,7 +84,7 @@ final class Condition
             } elseif (\is_string($key) && \is_array($val)) {
                 if(\preg_match('/^\$or[0-9]*$/', $key)) {
                     $ret[] = \sprintf('(%s)', $this->parse($val, ' OR '));
-                } elseif(\preg_match('/^\$or[0-9]*$/', $key)) {
+                } elseif(\preg_match('/^\$and[0-9]*$/', $key)) {
                     $ret[] = \sprintf('(%s)', $this->parse($val, ' AND '));
                 } else $ret[] = $this->parseExpression($key, $val, $logicalOperator);
             } elseif (\is_string($key) && \in_array(gettype($val), ['integer', 'double', 'string'])) {

--- a/src/Db/MySQL/Query/Utilities/Condition.php
+++ b/src/Db/MySQL/Query/Utilities/Condition.php
@@ -82,9 +82,11 @@ final class Condition
             if (\is_int($key) && \is_array($val)) {
                 $ret[] = $this->parse($val, $logicalOperator);
             } elseif (\is_string($key) && \is_array($val)) {
-                $ret[] = \preg_match('/^\$or[0-9]*$/', $key)
-                    ? \sprintf('(%s)', $this->parse($val, ' OR '))
-                    : $this->parseExpression($key, $val, $logicalOperator);
+                if(\preg_match('/^\$or[0-9]*$/', $key)) {
+                    $ret[] = \sprintf('(%s)', $this->parse($val, ' OR '));
+                } elseif(\preg_match('/^\$or[0-9]*$/', $key)) {
+                    $ret[] = \sprintf('(%s)', $this->parse($val, ' AND '));
+                } else $ret[] = $this->parseExpression($key, $val, $logicalOperator);
             } elseif (\is_string($key) && \in_array(gettype($val), ['integer', 'double', 'string'])) {
                 $ret[] = \sprintf('%s=%s', $key, $this->escapeClass->escape($val));
             }


### PR DESCRIPTION
small change in parser to be able to build db queries like this:
`AND ( (CONDITION A AND CONDITION B) OR CONDITION C)`

for example:
`$where['$or'] = [ '$and'=>['field1'=>[ '$gte'=>A, '$lte'=>B ]], 'fieldB'=>C];`